### PR TITLE
bugfix/Something may be undefined..... in Safari?

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: build npm package
-        uses: tfso/gh-action-helpers/npm-build@v1.8.0
+        uses: tfso/action-helpers/npm-build@v1
         id: npm
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/rollup.config.browser.js
+++ b/rollup.config.browser.js
@@ -1,12 +1,15 @@
+import path from 'path'
+
 import commonjs from '@rollup/plugin-commonjs'
 import resolve from '@rollup/plugin-node-resolve'
 import typescript from '@rollup/plugin-typescript'
+import config from './tsconfig-browser.json'
 
 export default {
     input: 'src/index.ts',
     output: [
         {
-            file: 'dist/TfsoAuth.js',
+            file: path.join(config.compilerOptions.outDir ?? '', 'TfsoAuth.js'),
             format: 'iife',
             exports: 'named',
             name: 'TfsoAuth'

--- a/rollup.config.browser.js
+++ b/rollup.config.browser.js
@@ -1,13 +1,12 @@
 import commonjs from '@rollup/plugin-commonjs'
 import resolve from '@rollup/plugin-node-resolve'
 import typescript from '@rollup/plugin-typescript'
-import pkg from './package.json'
 
 export default {
     input: 'src/index.ts',
     output: [
         {
-            file: pkg.globalModule,
+            file: 'dist/TfsoAuth.js',
             format: 'iife',
             exports: 'named',
             name: 'TfsoAuth'

--- a/rollup.config.browser.js
+++ b/rollup.config.browser.js
@@ -9,7 +9,7 @@ export default {
     input: 'src/index.ts',
     output: [
         {
-            file: path.join(config.compilerOptions.outDir ?? '', 'TfsoAuth.js'),
+            file: path.join(config.compilerOptions.outDir || '', 'TfsoAuth.js'),
             format: 'iife',
             exports: 'named',
             name: 'TfsoAuth'

--- a/src/AuthChangeNotifier.ts
+++ b/src/AuthChangeNotifier.ts
@@ -76,7 +76,7 @@ export class AuthChangeNotifier extends EventEmitter<Events>{
                 this._lastLoginCheck = currentTime
 
                 const identity = await this._authenticator.getCurrentlyLoggedInIdentityOrNull()
-                if(identity == null){
+                if(!identity){
                     this.emit('logout')
                 }
             }

--- a/src/AuthChangeNotifier.ts
+++ b/src/AuthChangeNotifier.ts
@@ -76,7 +76,7 @@ export class AuthChangeNotifier extends EventEmitter<Events>{
                 this._lastLoginCheck = currentTime
 
                 const identity = await this._authenticator.getCurrentlyLoggedInIdentityOrNull()
-                if(identity === null){
+                if(identity == null){
                     this.emit('logout')
                 }
             }

--- a/src/AuthManager.ts
+++ b/src/AuthManager.ts
@@ -163,7 +163,7 @@ export class AuthManager extends EventEmitter<Events>{
 
     async _handleAuthChange(){
         const identity = await this._authenticator.getCurrentlyLoggedInIdentityOrNull()
-        if(identity === null){
+        if(identity == null){
             return this._handleLoggedOut()
         }
 

--- a/src/AuthManager.ts
+++ b/src/AuthManager.ts
@@ -19,7 +19,7 @@ type Events =
     'authorization-failure'
 
 const userHasAllRequiredProfileInfo = (identity: Identity) => {
-    const hasClient = identity?.client?.id !== null && Number(identity?.client?.id) > 0
+    const hasClient = identity?.client?.id != null && Number(identity?.client?.id) > 0
     const hasRequiredLocale = identity?.locale?.country && identity?.locale?.culture && identity?.locale?.language
     return hasClient && hasRequiredLocale
 }
@@ -167,7 +167,7 @@ export class AuthManager extends EventEmitter<Events>{
             return this._handleLoggedOut()
         }
 
-        if(identity.license !== (this.identity !== null ? this.identity.license : '')){
+        if(identity.license !== (this.identity != null ? this.identity.license : '')){
             return this._handleLicenseChanged(identity)
         }
     }

--- a/src/AuthManager.ts
+++ b/src/AuthManager.ts
@@ -19,8 +19,8 @@ type Events =
     'authorization-failure'
 
 const userHasAllRequiredProfileInfo = (identity: Identity) => {
-    const hasClient = identity.client.id !== null && Number(identity.client.id) > 0
-    const hasRequiredLocale = identity.locale.country && identity.locale.culture && identity.locale.language
+    const hasClient = identity?.client?.id !== null && Number(identity?.client?.id) > 0
+    const hasRequiredLocale = identity?.locale?.country && identity?.locale?.culture && identity?.locale?.language
     return hasClient && hasRequiredLocale
 }
 

--- a/src/AuthManager.ts
+++ b/src/AuthManager.ts
@@ -163,7 +163,7 @@ export class AuthManager extends EventEmitter<Events>{
 
     async _handleAuthChange(){
         const identity = await this._authenticator.getCurrentlyLoggedInIdentityOrNull()
-        if(identity == null){
+        if(!identity){
             return this._handleLoggedOut()
         }
 

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -14,18 +14,18 @@ export class Authenticator{
 
     async getCurrentlyLoggedInIdentityOrNull(){
         const token = await this._getIdentityApiTokenOrNulIfAuthRequired()
-        if(token === null){
+        if(token == null){
             return null
         }
 
         let identity = await this._getIdentityOrNullIfCookieRequired()
 
-        if(identity === null){
+        if(identity == null){
             await this._setLegacyCookieIfPossible(token)
             identity = await this._getIdentityOrNullIfCookieRequired()
         }
 
-        if(identity === null){
+        if(identity == null){
             return null
         }
 
@@ -34,7 +34,7 @@ export class Authenticator{
 
     async ensureLoggedIn(){
         const identity = await this.getCurrentlyLoggedInIdentityOrNull()
-        if(identity === null){
+        if(identity == null){
             this.redirectToLogin()
             return
         }

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -14,18 +14,18 @@ export class Authenticator{
 
     async getCurrentlyLoggedInIdentityOrNull(){
         const token = await this._getIdentityApiTokenOrNulIfAuthRequired()
-        if(token == null){
+        if(!token){
             return null
         }
 
         let identity = await this._getIdentityOrNullIfCookieRequired()
 
-        if(identity == null){
+        if(!identity){
             await this._setLegacyCookieIfPossible(token)
             identity = await this._getIdentityOrNullIfCookieRequired()
         }
 
-        if(identity == null){
+        if(!identity){
             return null
         }
 
@@ -34,7 +34,7 @@ export class Authenticator{
 
     async ensureLoggedIn(){
         const identity = await this.getCurrentlyLoggedInIdentityOrNull()
-        if(identity == null){
+        if(!identity){
             this.redirectToLogin()
             return
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "outDir": "dist",
-    "module": "esnext",
-    "target": "esnext",
-    "lib": ["es2018", "dom"],
+    "module": "ESNext",
+    "target": "ES6",
+    "lib": ["ES2018", "DOM"],
     "sourceMap": true,
     "allowJs": false,
     "jsx": "react",


### PR DESCRIPTION
We have a strange issue in Safari where `identity.client` may be undefined. According to code it should reach https://github.com/tfso/js-tfso-auth/blob/3da9f0e3cd5633211de1fc20e1b5c0215e521eb7/src/AuthManager.ts#L22 at all when it doesn't have an identity.

There is a few strict checks for `null`, not catching `undefined`. A normal equality will also catch `undefined`. Maybe this will fix the issue.

![image](https://user-images.githubusercontent.com/4351799/215441285-75468945-3c71-438f-b388-e611c244ffba.png)
![image](https://user-images.githubusercontent.com/4351799/215441442-987280cc-a208-4a0f-865d-c556b63c81b1.png)
