### PR TITLE
chore/Authorization for environment-less

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # js-auth
 
-## Config
+## config
 
 The config object looks like this:
 

--- a/src/AuthManager.ts
+++ b/src/AuthManager.ts
@@ -74,6 +74,12 @@ export class AuthManager extends EventEmitter<Events>{
         this.emit('authentication-attempt')
         try{
             const identity: Identity = await this._authenticator.ensureLoggedIn()
+
+            if(identity === null) {
+                // no identity, we are waiting for a redirect to happen
+                return
+            }
+
             this.identity = identity // Set before emitting so it's available when consumer is reacting to the event
             if(this._config.requireValidProfile){
                 this.requireValidProfile(identity)
@@ -97,7 +103,7 @@ export class AuthManager extends EventEmitter<Events>{
 
     requireValidProfile(identity: Identity){
         if(!userHasAllRequiredProfileInfo(identity)){
-            document.location.href = 'https://app.24sevenoffice.com/modules/profile2/#profile'
+            document.location.href = '/modules/profile2/#profile'
         }
     }
 

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -15,8 +15,6 @@ export class Authenticator{
     async getCurrentlyLoggedInIdentityOrNull(){
         try {
             const token = await this._getIdentityApiTokenOrNulIfAuthRequired()
-            console.log('token')
-            console.log(token)
             if(!token){
                 return null
             }
@@ -43,8 +41,6 @@ export class Authenticator{
 
     async ensureLoggedIn(){
         const identity = await this.getCurrentlyLoggedInIdentityOrNull()
-        console.log('ensureLoggedIn')
-        console.log(identity)
         if(!identity){
             this.redirectToLogin()
             return null
@@ -119,12 +115,7 @@ export class Authenticator{
         }
 
         try{
-            console.log('_getIdentityApiTokenOrNulIfAuthRequired')
-            console.log(opts)
-            const token = await this._webAuth.checkSession(opts)
-            console.log(token)
-
-            return token
+            return await this._webAuth.checkSession(opts)
         }catch(error){
             const errorsWhereAuthIsRequired = [
                 'login_required',

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -41,7 +41,6 @@ export class Authenticator{
 
     async ensureLoggedIn(){
         const identity = await this.getCurrentlyLoggedInIdentityOrNull()
-        debugger;
         console.log('ensureLoggedIn')
         console.log(identity)
         if(!identity){
@@ -118,7 +117,12 @@ export class Authenticator{
         }
 
         try{
-            return await this._webAuth.checkSession(opts)
+            console.log('_getIdentityApiTokenOrNulIfAuthRequired')
+            console.log(opts)
+            const token = await this._webAuth.checkSession(opts)
+            console.log(token)
+
+            return token
         }catch(error){
             const errorsWhereAuthIsRequired = [
                 'login_required',

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -34,6 +34,9 @@ export class Authenticator{
 
     async ensureLoggedIn(){
         const identity = await this.getCurrentlyLoggedInIdentityOrNull()
+        debugger;
+        console.log('ensureLoggedIn')
+        console.log(identity)
         if(!identity){
             this.redirectToLogin()
             return

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -15,6 +15,8 @@ export class Authenticator{
     async getCurrentlyLoggedInIdentityOrNull(){
         try {
             const token = await this._getIdentityApiTokenOrNulIfAuthRequired()
+            console.log('token')
+            console.log(token)
             if(!token){
                 return null
             }


### PR DESCRIPTION
probably fixes an unhandled error log in Datadog RUM, where I think Safari is slow to do a javascript redirect, where it continues with the login procedure where identity is null.

[Datadog RUM](https://app.datadoghq.eu/rum/explorer?query=-%40error.source%3Anetwork%20env%3Aprod%20%40error.source%3Aconsole%20evaluating%20%27e.client%20%40type%3Aerror&cols=&index=%2A&type=rum&viz=stream&from_ts=1677452400000&to_ts=1678701720000&live=false)