### PR TITLE
bugfix/Configurable callback for session

### DIFF
--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -33,7 +33,7 @@ export class Authenticator{
             return identity
         }
         catch(err) {
-            console.error(err)
+            console.error('Not logged in', err)
 
             return null
         }
@@ -154,7 +154,7 @@ export class Authenticator{
         const opts = {
             audience: 'https://app.24sevenoffice.com',
             responseType: 'token',
-            redirectUri: `${window.location.origin}/modules/auth/login-callback`
+            redirectUri: this._config.sessionCallbackUrl
         }
 
         try{

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -154,7 +154,8 @@ export class Authenticator{
         const opts = {
             audience: 'https://app.24sevenoffice.com',
             responseType: 'token',
-            redirectUri: this._config.sessionCallbackUrl
+            redirectUri: this._config.sessionCallbackUrl,
+            prompt: 'none'
         }
 
         try{

--- a/src/Authorizer.ts
+++ b/src/Authorizer.ts
@@ -150,7 +150,7 @@ export class Authorizer extends EventEmitter<Events>{
             scope: tokenConfig.scopes.join(' '),
             state: `identityId:${identityId};clientId:${clientId};userId:${userId};unique:${++this._checkSessionCount}`,
             responseType: 'token',
-            redirectUri: `${window.location.origin}/modules/auth/login-callback`
+            redirectUri: this._config.sessionCallbackUrl
         }
 
         const checkSession = promisify<any>(this._webAuth.checkSession.bind(this._webAuth))

--- a/src/Authorizer.ts
+++ b/src/Authorizer.ts
@@ -150,7 +150,8 @@ export class Authorizer extends EventEmitter<Events>{
             scope: tokenConfig.scopes.join(' '),
             state: `identityId:${identityId};clientId:${clientId};userId:${userId};unique:${++this._checkSessionCount}`,
             responseType: 'token',
-            redirectUri: this._config.sessionCallbackUrl
+            redirectUri: this._config.sessionCallbackUrl,
+            prompt: 'none'
         }
 
         const checkSession = promisify<any>(this._webAuth.checkSession.bind(this._webAuth))

--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -1,4 +1,6 @@
-export default {
+import { AuthenticatorConfig } from "./types"
+
+const config: AuthenticatorConfig = {
     optionsAuth0: {
         clientID: 'INGoYuDZDgaxT8JOL64M7vnJcxEGxCi0',
         domain: 'login.24SevenOffice.com',
@@ -8,5 +10,8 @@ export default {
     authenticateJwtUrl: '/login/data/AuthenticateJwt.aspx',
     loginUrl: () => `/modules/auth/login/?returnUrl=${encodeURIComponent(window.location.origin + window.location.pathname)}`,
     logoutUrl: () => `/modules/auth/logout`,
-    callbackUrl: `${window.location.origin}/modules/auth/login-callback?isSilent=true`
+    callbackUrl: `${window.location.origin}/modules/auth/login-callback`,
+    sessionCallbackUrl: `${window.location.origin}/modules/auth/login-callback`
 }
+
+export default config

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export {AuthChangeNotifier} from './AuthChangeNotifier'
 export {AuthManager} from './AuthManager'
 
 export const createAuthManager = (authManagerConfig: Partial<AuthManagerConfig>, authenticatorConfig: Partial<AuthenticatorConfig>) => {
-    const webAuth = new WebAuth(authenticatorConfig.optionsAuth0 ?? defaultConfig.optionsAuth0 )
+    const webAuth = new WebAuth({ ...defaultConfig.optionsAuth0, ...authenticatorConfig.optionsAuth0 ?? {} })
 
     const authenticator = new Authenticator(authenticatorConfig, webAuth)
     const authorizer = new Authorizer(authenticatorConfig, webAuth)

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export interface AuthenticatorConfig{
     loginUrl: string | (() => string)
     logoutUrl: string | (() => string)
     callbackUrl: string
+    sessionCallbackUrl: string
 }
 
 export type AuthorizerConfig = AuthenticatorConfig


### PR DESCRIPTION
https://github.com/tfso/js-tfso-auth/pull/30/commits/d186f727d2353148a2a93fbeee30e6d721cd0cb2 in #30 caused issues for other environments that don't have /modules/* (like oflow, prisolve etc with own domains).

Adding two different callback url configs, one for silent auth check, and one for login. 