### PR TITLE
chore/Expose webauth

### DIFF
--- a/src/AuthManager.ts
+++ b/src/AuthManager.ts
@@ -16,8 +16,7 @@ type Events =
     'authorization-complete' |
     'authorization-attempt' |
     'authorization-success' |
-    'authorization-failure' | 
-    'debug'
+    'authorization-failure'
 
 const userHasAllRequiredProfileInfo = (identity: Identity) => {
     const hasClient = identity?.client?.id != null && Number(identity?.client?.id) > 0
@@ -54,7 +53,6 @@ export class AuthManager extends EventEmitter<Events>{
 
         this._authorizer.on('access-success', access => this._handleAuthorizationSuccess(access))
         this._authorizer.on('access-failure', access => this._handleAuthorizationFailure(access))
-        this._authorizer.on('debug', message => this.emit('debug', message))
         this._authenticator.on('error', (message, err) => { 
             if(this.listenerCount('authentication-error') > 0) {
                 this.emit('authentication-error', message, err)
@@ -64,7 +62,7 @@ export class AuthManager extends EventEmitter<Events>{
                 console.error(err) 
             }
         })
-        this._authenticator.on('debug', message => this.emit('debug', message))
+
     }
 
     /*
@@ -82,7 +80,6 @@ export class AuthManager extends EventEmitter<Events>{
     on(event: 'authorization-attempt', fn: (event: {tokenConfig: TokenConfig, license: string}) => void, context?: any): this
     on(event: 'authorization-success', fn: (event: {access: AccessSuccess}) => void, context?: any): this
     on(event: 'authorization-failure', fn: (event: {access: AccessFailure}) => void, context?: any): this
-    on(event: 'debug', fn: (message: string) => void, context?: any): this
     on(event: Events, fn: EventEmitter.ListenerFn, context?: any): this{
         return super.on(event, fn, context)
     }
@@ -97,7 +94,6 @@ export class AuthManager extends EventEmitter<Events>{
 
             const identity = await this._authenticator.getCurrentlyLoggedInIdentityOrNull()
 
-            this.emit('debug', `AuthManager: Login and currently identity ${identity?.license}`)
             if(identity === null) {
                 this._authenticator.login()
 
@@ -145,7 +141,6 @@ export class AuthManager extends EventEmitter<Events>{
     }
 
     async logout(returnUrl?: string){
-        this.emit('debug', `AuthManager: Logging out`)
         try{
             this._authChangeNotifier?.disable()
 
@@ -192,8 +187,6 @@ export class AuthManager extends EventEmitter<Events>{
         const defaultHandler = () => { }
 
         if(this._config.logoutHandler){
-            this.emit('debug', `AuthManager: Using custom logout handler`)
-
             this._config.logoutHandler(defaultHandler)
         }
     }
@@ -208,7 +201,6 @@ export class AuthManager extends EventEmitter<Events>{
         const defaultHandler = () => window.location.reload()
 
         if(this._config.licenseChangeHandler){
-            this.emit('debug', `AuthManager: Using custom license change handler`)
             this._config.licenseChangeHandler(event, defaultHandler)
         }else{
             defaultHandler()
@@ -228,8 +220,6 @@ export class AuthManager extends EventEmitter<Events>{
         if(!identity){
             return this.logout(window.location.href)
         }
-
-        this.emit('debug', `AuthManager: Handling auth change to ${attemptedLicense}`)
 
         if(identity.license !== (this.identity?.license ?? '')){
             return this._handleLicenseChanged(identity)

--- a/src/AuthManager.ts
+++ b/src/AuthManager.ts
@@ -134,7 +134,7 @@ export class AuthManager extends EventEmitter<Events>{
     }
 
     async logout(returnUrl?: string){
-        this._handleLoggedOut()
+        this._handleLoggedOut(returnUrl)
         
         return this._authenticator.logout(returnUrl)
     }
@@ -165,15 +165,13 @@ export class AuthManager extends EventEmitter<Events>{
         return this._config.tokens
     }
 
-    private _handleLoggedOut(){
+    private _handleLoggedOut(returnUrl?: string){
         this.emit('authentication-logout')
 
-        const defaultHandler = () => this._authenticator.login()
+        const defaultHandler = () => { }
 
         if(this._config.logoutHandler){
             this._config.logoutHandler(defaultHandler)
-        }else{
-            defaultHandler()
         }
     }
 
@@ -204,7 +202,8 @@ export class AuthManager extends EventEmitter<Events>{
     private async _handleAuthChange(attemptedLicense?: string){
         const identity = await this._authenticator.getCurrentlyLoggedInIdentityOrNull(attemptedLicense)
         if(!identity){
-            return this._handleLoggedOut()
+            this._handleLoggedOut()
+            this._authenticator.login(window.location.href)
         }
 
         if(identity.license !== (this.identity != null ? this.identity.license : '')){

--- a/src/AuthManager.ts
+++ b/src/AuthManager.ts
@@ -165,7 +165,7 @@ export class AuthManager extends EventEmitter<Events>{
         return this._config.tokens
     }
 
-    private _handleLoggedOut(returnUrl?: string){
+    private _handleLoggedOut(){
         this.emit('authentication-logout')
 
         const defaultHandler = () => { }

--- a/src/AuthManager.ts
+++ b/src/AuthManager.ts
@@ -134,7 +134,7 @@ export class AuthManager extends EventEmitter<Events>{
     }
 
     async logout(returnUrl?: string){
-        this._handleLoggedOut(returnUrl)
+        this._handleLoggedOut()
         
         return this._authenticator.logout(returnUrl)
     }

--- a/src/AuthManager.ts
+++ b/src/AuthManager.ts
@@ -108,6 +108,8 @@ export class AuthManager extends EventEmitter<Events>{
             this.identity = null
             this.emit('authentication-failure', {err})
             
+            this._authenticator.login()
+
             return false
         }
         finally {
@@ -146,7 +148,7 @@ export class AuthManager extends EventEmitter<Events>{
     async logout(returnUrl?: string){
         try {
             this._authChangeNotifier.disable()
-            
+
             this.emit('debug', `AuthManager: Logging out`)
 
             this._handleLoggedOut()

--- a/src/AuthManager.ts
+++ b/src/AuthManager.ts
@@ -87,8 +87,9 @@ export class AuthManager extends EventEmitter<Events>{
     async login(){
         this.emit('authentication-attempt')
         try{
-            const identity: Identity = await this._authenticator.getCurrentlyLoggedInIdentityOrNull()
+            const identity = await this._authenticator.getCurrentlyLoggedInIdentityOrNull()
 
+            this.emit('debug', `AuthManager: Login and currently identity ${identity?.license}`)
             if(identity === null) {
                 this._authenticator.login()
 

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -109,6 +109,8 @@ export class Authenticator extends EventEmitter<Events> {
 
         this.emit('debug', `Authenticator: Logging in`)
 
+        this._removeAuth0TemporaryCookies()
+
         this._webAuth.authorize({
             audience: 'https://app.24sevenoffice.com',
             responseType: 'token',
@@ -277,6 +279,15 @@ export class Authenticator extends EventEmitter<Events> {
         )
     }
 
+    private _removeAuth0TemporaryCookies() {
+        for(const cookie of document.cookie.split(';')) {
+            const name = cookie.trim().split('=')[0]
+            
+            if (name.startsWith('_com.auth0.auth.') || name.startsWith('com.auth0.auth.')) {
+                document.cookie = `${name}=; Domain=${location.hostname}; Path=/; Secure; SameSite=None; Expires=${new Date(0).toUTCString()}`
+            }
+        }
+    }
 }
 
 const cacheBustUrl = url => {

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -42,7 +42,7 @@ export class Authenticator extends EventEmitter<Events> {
             : this._config.logoutUrl
     }
 
-    async getCurrentlyLoggedInIdentityOrNull(attemptedLicense?: string) {
+    async getCurrentlyLoggedInIdentityOrNull(attemptedLicense?: string): Promise<types.Identity | null> {
         try {
             if(this._identityIsBeingFetched)
                 await assert(() => !this._identityIsBeingFetched)

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -115,18 +115,17 @@ export class Authenticator extends EventEmitter<Events> {
 
     /**
      * Verify callback from login provider
-     * @returns The token if the user is logged in, otherwise null
+     * @returns The identity if the user is logged in, otherwise null
      * @throws {{ error: string, errorDescription: string, state?: string }} If the user is not logged in
      */
-    async callback(): Promise<Auth0DecodedHash | null> {
-
-
+    async callback(): Promise<Record<string, any> | null> {
         const parseHarsh = promisify(this._webAuth.parseHash.bind(this._webAuth))
         const token = await parseHarsh()
 
         await this._setLegacyCookieIfPossible(token)
 
-        return token
+        const identity = this._getIdentityOrNullIfCookieRequired()
+        return identity
     }
 
     redirectToLogin(){

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -23,7 +23,7 @@ export class Authenticator extends EventEmitter<Events> {
     constructor(config: Partial<types.AuthenticatorConfig>, private _webAuth: WebAuth) {
         super()
 
-        this._config = { ...defaultConfig, ...config ?? {} }
+        this._config = { ...defaultConfig, ...config ?? {}, optionsAuth0: { ...defaultConfig.optionsAuth0, ...config.optionsAuth0 ?? {} } }
     }
 
     get webAuth() {

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -80,13 +80,17 @@ export class Authenticator extends EventEmitter<Events> {
         return identity
     }
 
-    login() {
+    login(returnUrl?: string) {
         const redirectUrl = new URL(this._config.callbackUrl ?? `/modules/auth/login-callback`, window.location.origin)
 
         if(window.location.search){
             for(let [key, value] of new URLSearchParams(window.location.search)){
                 redirectUrl.searchParams.append(key, value)
             }
+        }
+
+        if(returnUrl){
+            redirectUrl.searchParams.set('returnTo', returnUrl)
         }
 
         this._webAuth.authorize({
@@ -104,7 +108,7 @@ export class Authenticator extends EventEmitter<Events> {
             fetch(`${this._baseUrl}/login/data/Logout.aspx`, { method: 'POST', credentials: 'same-origin' })
         ])
 
-        this._webAuth.logout({ 
+        this._webAuth.logout({
             returnTo
         })
     }
@@ -115,6 +119,8 @@ export class Authenticator extends EventEmitter<Events> {
      * @throws {{ error: string, errorDescription: string, state?: string }} If the user is not logged in
      */
     async callback(): Promise<Auth0DecodedHash | null> {
+
+
         const parseHarsh = promisify(this._webAuth.parseHash.bind(this._webAuth))
         const token = await parseHarsh()
 

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -5,7 +5,7 @@ import * as types from './types'
 import defaultConfig from './defaultConfig'
 import promisify from './promisify'
 
-type Events = 'error' | 'debug'
+type Events = 'error'
 
 class HttpError extends Error {
     constructor(public status: number, public statusText: string, public headers?: Response["headers"], public body?: Record<string, any>) {
@@ -102,12 +102,8 @@ export class Authenticator extends EventEmitter<Events> {
         }
 
         if(returnUrl){
-            this.emit('debug', `Authenticator: Logging in with return url "${returnUrl}"`)
-
             redirectUrl.searchParams.set('returnUrl', returnUrl)
         }
-
-        this.emit('debug', `Authenticator: Logging in`)
 
         this._removeAuth0TemporaryCookies()
 
@@ -122,18 +118,13 @@ export class Authenticator extends EventEmitter<Events> {
         const returnTo = new URL(this.loginUrl ?? `${this._baseUrl}/modules/auth/login/`, window.location.origin)
         
         if(returnUrl){
-            this.emit('debug', `Authenticator: Logging out with return url "${returnUrl}"`)
             returnTo.searchParams.set('returnUrl', returnUrl)
         }
-
-        this.emit('debug', `Authenticator: Logging out of legacy services`)
 
         await Promise.all([
             fetch(`${this._baseUrl}/script/client/login/logoff.asp?_dc=${Date.now()}`, { credentials: 'same-origin' }),
             fetch(`${this._baseUrl}/login/data/Logout.aspx`, { method: 'POST', credentials: 'same-origin' })
         ])
-
-        this.emit('debug', `Authenticator: Logging out of Auth0`)
 
         this._webAuth.logout({
             returnTo: returnTo.toString()
@@ -146,8 +137,6 @@ export class Authenticator extends EventEmitter<Events> {
      * @throws {{ error: string, errorDescription: string, state?: string }} If the user is not logged in
      */
     async callback(): Promise<Record<string, any> | null> {
-        this.emit('debug', `Authenticator: Handling callback`)
-
         const parseHarsh = promisify(this._webAuth.parseHash.bind(this._webAuth))
         const token = await parseHarsh()
 
@@ -194,8 +183,6 @@ export class Authenticator extends EventEmitter<Events> {
 
     private async _setLegacyCookieIfPossible(token: types.Auth0Token){
         try{
-            this.emit('debug', `Authenticator: Setting Legacy cookie`)
-
             await fetch(this._config.authenticateJwtUrl, {
                 method: 'POST',
                 credentials: 'same-origin',

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -26,6 +26,10 @@ export class Authenticator extends EventEmitter<Events> {
         this._config = { ...defaultConfig, ...config ?? {} }
     }
 
+    get webAuth() {
+        return this._webAuth
+    }
+
     async getCurrentlyLoggedInIdentityOrNull(attemptedLicense?: string) {
         try {
             if(this._identityIsBeingFetched)

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -102,7 +102,7 @@ export class Authenticator extends EventEmitter<Events> {
 
     async logout(returnUrl?: string) {
         const loginUrl = typeof this._config.loginUrl == 'function' ? this._config.loginUrl() : this._config.loginUrl
-        const returnTo = returnUrl ?? loginUrl ?? `${this._baseUrl}/modules/auth/login/`
+        const returnTo = new URL(returnUrl ?? loginUrl ?? `${this._baseUrl}/modules/auth/login/`, window.location.origin).toString()
 
         await Promise.all([
             fetch(`${this._baseUrl}/script/client/login/logoff.asp?_dc=${Date.now()}`, { credentials: 'same-origin' }),

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -101,7 +101,8 @@ export class Authenticator extends EventEmitter<Events> {
     }
 
     async logout(returnUrl?: string) {
-        const returnTo = returnUrl ?? `${this._baseUrl}/login`
+        const loginUrl = typeof this._config.loginUrl == 'function' ? this._config.loginUrl() : this._config.loginUrl
+        const returnTo = returnUrl ?? loginUrl ?? `${this._baseUrl}/modules/auth/login/`
 
         await Promise.all([
             fetch(`${this._baseUrl}/script/client/login/logoff.asp?_dc=${Date.now()}`, { credentials: 'same-origin' }),

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -31,9 +31,9 @@ export class Authenticator extends EventEmitter<Events> {
     }
 
     private get loginUrl() {
-        return typeof this._config.logoutUrl === 'function'
-            ? this._config.logoutUrl()
-            : this._config.logoutUrl
+        return typeof this._config.loginUrl === 'function'
+            ? this._config.loginUrl()
+            : this._config.loginUrl
     }
 
     private get logoutUrl() {
@@ -193,7 +193,7 @@ export class Authenticator extends EventEmitter<Events> {
     private async _setLegacyCookieIfPossible(token: types.Auth0Token){
         try{
             this.emit('debug', `Authenticator: Setting Legacy cookie`)
-            
+
             await fetch(this._config.authenticateJwtUrl, {
                 method: 'POST',
                 credentials: 'same-origin',

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -102,7 +102,11 @@ export class Authenticator extends EventEmitter<Events> {
 
     async logout(returnUrl?: string) {
         const loginUrl = typeof this._config.loginUrl == 'function' ? this._config.loginUrl() : this._config.loginUrl
-        const returnTo = new URL(returnUrl ?? loginUrl ?? `${this._baseUrl}/modules/auth/login/`, window.location.origin).toString()
+        const returnTo = new URL(loginUrl ?? `${this._baseUrl}/modules/auth/login/`, window.location.origin)
+        
+        if(returnUrl){
+            returnTo.searchParams.set('returnUrl', returnUrl)
+        }
 
         await Promise.all([
             fetch(`${this._baseUrl}/script/client/login/logoff.asp?_dc=${Date.now()}`, { credentials: 'same-origin' }),
@@ -110,7 +114,7 @@ export class Authenticator extends EventEmitter<Events> {
         ])
 
         this._webAuth.logout({
-            returnTo
+            returnTo: returnTo.toString()
         })
     }
 

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -191,7 +191,7 @@ export class Authenticator extends EventEmitter<Events> {
         const opts = {
             audience: 'https://app.24sevenoffice.com',
             responseType: 'token',
-            redirectUri: this._config.sessionCallbackUrl,
+            redirectUri: this._config.sessionCallbackUrl ?? this._config.callbackUrl,
             prompt: 'none'
         }
 

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -30,6 +30,18 @@ export class Authenticator extends EventEmitter<Events> {
         return this._webAuth
     }
 
+    private get loginUrl() {
+        return typeof this._config.logoutUrl === 'function'
+            ? this._config.logoutUrl()
+            : this._config.logoutUrl
+    }
+
+    private get logoutUrl() {
+        return typeof this._config.logoutUrl === 'function'
+            ? this._config.logoutUrl()
+            : this._config.logoutUrl
+    }
+
     async getCurrentlyLoggedInIdentityOrNull(attemptedLicense?: string) {
         try {
             if(this._identityIsBeingFetched)
@@ -90,7 +102,7 @@ export class Authenticator extends EventEmitter<Events> {
         }
 
         if(returnUrl){
-            redirectUrl.searchParams.set('returnTo', returnUrl)
+            redirectUrl.searchParams.set('returnUrl', returnUrl)
         }
 
         this._webAuth.authorize({
@@ -101,8 +113,7 @@ export class Authenticator extends EventEmitter<Events> {
     }
 
     async logout(returnUrl?: string) {
-        const loginUrl = typeof this._config.loginUrl == 'function' ? this._config.loginUrl() : this._config.loginUrl
-        const returnTo = new URL(loginUrl ?? `${this._baseUrl}/modules/auth/login/`, window.location.origin)
+        const returnTo = new URL(this.loginUrl ?? `${this._baseUrl}/modules/auth/login/`, window.location.origin)
         
         if(returnUrl){
             returnTo.searchParams.set('returnUrl', returnUrl)
@@ -133,16 +144,12 @@ export class Authenticator extends EventEmitter<Events> {
         return identity
     }
 
-    redirectToLogin(){
-        window.location.href = typeof this._config.loginUrl === 'function'
-            ? this._config.loginUrl()
-            : this._config.loginUrl
+    public redirectToLogin(){
+        window.location.href = this.loginUrl
     }
 
-    redirectToLogout(){
-        window.location.href = typeof this._config.logoutUrl === 'function'
-            ? this._config.logoutUrl()
-            : this._config.logoutUrl
+    public redirectToLogout(){
+        window.location.href = this.logoutUrl
     }
 
     private async _getIdentityOrNullIfCookieRequired(){

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -5,7 +5,7 @@ import * as types from './types'
 import defaultConfig from './defaultConfig'
 import promisify from './promisify'
 
-type Events = 'error'
+type Events = 'error' | 'debug'
 
 class HttpError extends Error {
     constructor(public status: number, public statusText: string, public headers?: Response["headers"], public body?: Record<string, any>) {
@@ -102,8 +102,12 @@ export class Authenticator extends EventEmitter<Events> {
         }
 
         if(returnUrl){
+            this.emit('debug', `Authenticator: Logging in with return url "${returnUrl}"`)
+
             redirectUrl.searchParams.set('returnUrl', returnUrl)
         }
+
+        this.emit('debug', `Authenticator: Logging in`)
 
         this._webAuth.authorize({
             audience: 'https://app.24sevenoffice.com',
@@ -116,13 +120,18 @@ export class Authenticator extends EventEmitter<Events> {
         const returnTo = new URL(this.loginUrl ?? `${this._baseUrl}/modules/auth/login/`, window.location.origin)
         
         if(returnUrl){
+            this.emit('debug', `Authenticator: Logging out with return url "${returnUrl}"`)
             returnTo.searchParams.set('returnUrl', returnUrl)
         }
+
+        this.emit('debug', `Authenticator: Logging out of legacy services`)
 
         await Promise.all([
             fetch(`${this._baseUrl}/script/client/login/logoff.asp?_dc=${Date.now()}`, { credentials: 'same-origin' }),
             fetch(`${this._baseUrl}/login/data/Logout.aspx`, { method: 'POST', credentials: 'same-origin' })
         ])
+
+        this.emit('debug', `Authenticator: Logging out of Auth0`)
 
         this._webAuth.logout({
             returnTo: returnTo.toString()
@@ -135,6 +144,8 @@ export class Authenticator extends EventEmitter<Events> {
      * @throws {{ error: string, errorDescription: string, state?: string }} If the user is not logged in
      */
     async callback(): Promise<Record<string, any> | null> {
+        this.emit('debug', `Authenticator: Handling callback`)
+
         const parseHarsh = promisify(this._webAuth.parseHash.bind(this._webAuth))
         const token = await parseHarsh()
 
@@ -181,6 +192,8 @@ export class Authenticator extends EventEmitter<Events> {
 
     private async _setLegacyCookieIfPossible(token: types.Auth0Token){
         try{
+            this.emit('debug', `Authenticator: Setting Legacy cookie`)
+            
             await fetch(this._config.authenticateJwtUrl, {
                 method: 'POST',
                 credentials: 'same-origin',

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -1,4 +1,4 @@
-import { Auth0DecodedHash, WebAuth } from 'auth0-js'
+import { WebAuth } from 'auth0-js'
 import EventEmitter from 'eventemitter3'
 
 import * as types from './types'

--- a/src/Authorizer.ts
+++ b/src/Authorizer.ts
@@ -148,7 +148,8 @@ export class Authorizer extends EventEmitter<Events>{
         const opts: CheckSessionOptions = {
             audience: tokenConfig.audience,
             scope: tokenConfig.scopes.join(' '),
-            //state: `identityId:${identityId};clientId:${clientId};userId:${userId};unique:${++this._checkSessionCount}`, // replaced with login_license hint below
+            state: `identityId:${identityId};clientId:${clientId};userId:${userId};unique:${++this._checkSessionCount}`,
+            //login_hint: `${identityId};${clientId};${userId}`,
             responseType: 'token',
             redirectUri: this._config.sessionCallbackUrl ?? this._config.callbackUrl,
             prompt: 'none'
@@ -156,7 +157,7 @@ export class Authorizer extends EventEmitter<Events>{
 
         const checkSession = promisify<any>(this._webAuth.checkSession.bind(this._webAuth))
         try{
-            const token = await checkSession({ ...opts, login_license: `${identityId};${clientId};${userId}` })
+            const token = await checkSession(opts)
             const expiresAt = token.expiresIn !== undefined ? token.expiresIn + Date.now() : null
 
             return {type: 'success', tokenConfig, token, error: null, license, expiresAt}

--- a/src/Authorizer.ts
+++ b/src/Authorizer.ts
@@ -148,7 +148,7 @@ export class Authorizer extends EventEmitter<Events>{
         const opts: CheckSessionOptions = {
             audience: tokenConfig.audience,
             scope: tokenConfig.scopes.join(' '),
-            //state: `identityId:${identityId};clientId:${clientId};userId:${userId};unique:${++this._checkSessionCount}`,
+            //state: `identityId:${identityId};clientId:${clientId};userId:${userId};unique:${++this._checkSessionCount}`, // replaced with login_license hint below
             responseType: 'token',
             redirectUri: this._config.sessionCallbackUrl,
             prompt: 'none'

--- a/src/Authorizer.ts
+++ b/src/Authorizer.ts
@@ -165,18 +165,6 @@ export class Authorizer extends EventEmitter<Events>{
             return {type: 'success', tokenConfig, token, error: null, license, expiresAt}
         }catch(error) {
             return {type: 'error', tokenConfig, token: null, error, license}
-        }finally {
-            this._removeAuth0TemporaryCookies()
-        }
-    }
-
-    private _removeAuth0TemporaryCookies() {
-        for(const cookie of document.cookie.split(';')) {
-            const name = cookie.trim().split('=')[0]
-            
-            if (name.startsWith('_com.auth0.auth.') || name.startsWith('com.auth0.auth.')) {
-                document.cookie = `${name}=; Domain=${location.hostname}; Path=/; Secure; SameSite=None; Expires=${new Date(0).toUTCString()}`
-            }
         }
     }
 }

--- a/src/Authorizer.ts
+++ b/src/Authorizer.ts
@@ -6,7 +6,7 @@ import defaultConfig from './defaultConfig'
 import {AccessFailure, AccessSuccess, TokenConfig} from './types'
 import promisify from './promisify'
 
-type Events = 'access-success' | 'access-failure'
+type Events = 'access-success' | 'access-failure' | 'debug'
 
 export class Authorizer extends EventEmitter<Events>{
     _config: types.AuthorizerConfig
@@ -154,6 +154,8 @@ export class Authorizer extends EventEmitter<Events>{
             redirectUri: this._config.sessionCallbackUrl ?? this._config.callbackUrl,
             prompt: 'none'
         }
+
+        this.emit('debug', `Authorizer: Checking session`)
 
         const checkSession = promisify<any>(this._webAuth.checkSession.bind(this._webAuth))
         try{

--- a/src/Authorizer.ts
+++ b/src/Authorizer.ts
@@ -21,7 +21,7 @@ export class Authorizer extends EventEmitter<Events>{
     constructor(config: Partial<types.AuthorizerConfig>, private _webAuth: WebAuth){
         super()
 
-        this._config = { ...defaultConfig, ...config ?? {} }
+        this._config = { ...defaultConfig, ...config ?? {}, optionsAuth0: { ...defaultConfig.optionsAuth0, ...config.optionsAuth0 ?? {} } }
     }
 
     /**

--- a/src/Authorizer.ts
+++ b/src/Authorizer.ts
@@ -150,7 +150,7 @@ export class Authorizer extends EventEmitter<Events>{
             scope: tokenConfig.scopes.join(' '),
             //state: `identityId:${identityId};clientId:${clientId};userId:${userId};unique:${++this._checkSessionCount}`, // replaced with login_license hint below
             responseType: 'token',
-            redirectUri: this._config.sessionCallbackUrl,
+            redirectUri: this._config.sessionCallbackUrl ?? this._config.callbackUrl,
             prompt: 'none'
         }
 

--- a/src/Authorizer.ts
+++ b/src/Authorizer.ts
@@ -6,7 +6,7 @@ import defaultConfig from './defaultConfig'
 import {AccessFailure, AccessSuccess, TokenConfig} from './types'
 import promisify from './promisify'
 
-type Events = 'access-success' | 'access-failure' | 'debug'
+type Events = 'access-success' | 'access-failure'
 
 export class Authorizer extends EventEmitter<Events>{
     _config: types.AuthorizerConfig
@@ -155,15 +155,13 @@ export class Authorizer extends EventEmitter<Events>{
             prompt: 'none'
         }
 
-        this.emit('debug', `Authorizer: Checking session`)
-
         const checkSession = promisify<any>(this._webAuth.checkSession.bind(this._webAuth))
+
         try{
             const token = await checkSession(opts)
             const expiresAt = token.expiresIn !== undefined ? token.expiresIn + Date.now() : null
-
             return {type: 'success', tokenConfig, token, error: null, license, expiresAt}
-        }catch(error) {
+        }catch(error){
             return {type: 'error', tokenConfig, token: null, error, license}
         }
     }

--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -11,7 +11,7 @@ const config: AuthenticatorConfig = {
     loginUrl: () => `/modules/auth/login/?returnUrl=${encodeURIComponent(window.location.origin + window.location.pathname)}`,
     logoutUrl: () => `/modules/auth/logout`,
     callbackUrl: `${window.location.origin}/modules/auth/login-callback`,
-    sessionCallbackUrl: `${window.location.origin}/modules/auth/login-callback`
+    sessionCallbackUrl: undefined
 }
 
 export default config

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,11 +13,22 @@ export {AuthChangeNotifier} from './AuthChangeNotifier'
 export {AuthManager} from './AuthManager'
 
 export const createAuthManager = (authManagerConfig: Partial<AuthManagerConfig>, authenticatorConfig: Partial<AuthenticatorConfig>) => {
-    const webAuth = new WebAuth({ ...defaultConfig.optionsAuth0, ...authenticatorConfig.optionsAuth0 ?? {} })
+    const webAuth = new WebAuth({ ...defaultConfig.optionsAuth0, ...cleanConfig(authenticatorConfig.optionsAuth0 ?? {}) })
 
-    const authenticator = new Authenticator(authenticatorConfig, webAuth)
-    const authorizer = new Authorizer(authenticatorConfig, webAuth)
+    const authenticator = new Authenticator(cleanConfig(authenticatorConfig), webAuth)
+    const authorizer = new Authorizer(cleanConfig(authenticatorConfig), webAuth)
     const authManager = new AuthManager(authenticator, authorizer, authManagerConfig)
 
     return authManager
+}
+
+function cleanConfig(config?: Record<string, any>) {
+    if(config && typeof config == 'object') {   
+        return Object
+            .entries(config ?? {})
+            .filter(([, value]) => value !== undefined)
+            .reduce((acc, [key, value]) => ({ ...acc, [key]: cleanConfig(value) }), {})
+    }
+
+    return config
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ export interface AuthenticatorConfig{
     loginUrl: string | (() => string)
     logoutUrl: string | (() => string)
     callbackUrl: string
-    sessionCallbackUrl: string
+    sessionCallbackUrl?: string
 }
 
 export type AuthorizerConfig = AuthenticatorConfig

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export interface AuthManagerConfig{
     licenseChangeHandler?: (event: LicenseChangeEvent, defaultHandler: () => void) => any
     tokens: TokenConfig[]
     requireValidProfile: boolean
+    disableNotifier?: boolean
 }
 
 export interface TokenConfig{


### PR DESCRIPTION
Changes:
- possibility to disable Ably notifier when doing auth actions in other tabs
- fixing disabling of Ably notifier for certain auth actions
- logout optimizations
- redirect to login if login-routine caught exception
- trying to remove com.auth0 cookies when doing login, these tokens is used for callback when authentication and authorizing and should be kept until that is done. 

currenty used at beta for `/modules/dashboard` and `/modules/auth`
